### PR TITLE
Fix float equality comparisons in AmountMatcherRule and TransferMatchingService

### DIFF
--- a/src/main/java/ca/jonathanfritz/ofxcat/cleaner/rules/AmountMatcherRule.java
+++ b/src/main/java/ca/jonathanfritz/ofxcat/cleaner/rules/AmountMatcherRule.java
@@ -27,7 +27,7 @@ public class AmountMatcherRule {
 
     public boolean match(OfxTransaction ofxTransaction) {
         if (isEqualToMatcher != null) {
-            return ofxTransaction.getAmount() == isEqualToMatcher;
+            return Float.compare(ofxTransaction.getAmount(), isEqualToMatcher) == 0;
         } else if (isGreaterThanMatcher != null) {
             return ofxTransaction.getAmount() > isGreaterThanMatcher;
         } else if (isLessThanMatcher != null) {

--- a/src/main/java/ca/jonathanfritz/ofxcat/service/TransferMatchingService.java
+++ b/src/main/java/ca/jonathanfritz/ofxcat/service/TransferMatchingService.java
@@ -44,7 +44,7 @@ public class TransferMatchingService {
         for (Transaction source : sourceTransactions) {
             final List<Transaction> potentialSinks = sinkTransactions.stream()
                     .filter(t -> t.getDate().equals(source.getDate()))
-                    .filter(t -> Double.compare(t.getAmount(), -source.getAmount()) == 0)
+                    .filter(t -> Float.compare(t.getAmount(), -source.getAmount()) == 0)
                     .filter(t -> !t.getAccount().equals(source.getAccount()))
                     .toList();
 


### PR DESCRIPTION
## Summary

- `AmountMatcherRule`: replaced `==` with `Float.compare() == 0` to fix a genuine correctness bug where two floats representing the same dollar amount could have different bit patterns and fail the equality check
- `TransferMatchingService`: replaced `Double.compare()` with `Float.compare()` — the existing code promoted floats to double before comparing, which worked in practice (IEEE 754 negation is exact) but was misleading; this makes the intent clear

These were identified during a float-precision audit of the codebase ahead of implementing gap detection, which requires reliable balance comparisons.

## Test plan

- [ ] `./gradlew verify` passes (no behaviour change expected — the transfer matching bug was latent, not triggered by current tests)
- [ ] Manually verify transfer detection still works on a real OFX file with inter-account transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)