### PR TITLE
Report skipped duplicate count after transaction import

### DIFF
--- a/src/main/java/ca/jonathanfritz/ofxcat/service/ImportResult.java
+++ b/src/main/java/ca/jonathanfritz/ofxcat/service/ImportResult.java
@@ -1,0 +1,6 @@
+package ca.jonathanfritz.ofxcat.service;
+
+import ca.jonathanfritz.ofxcat.datastore.dto.CategorizedTransaction;
+import java.util.List;
+
+public record ImportResult(List<CategorizedTransaction> transactions, int duplicateCount) {}

--- a/src/main/java/ca/jonathanfritz/ofxcat/service/TransactionImportService.java
+++ b/src/main/java/ca/jonathanfritz/ofxcat/service/TransactionImportService.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -105,12 +106,18 @@ public class TransactionImportService {
             throw new OfxCatException("An unexpected exception occurred", e);
         }
 
-        final List<CategorizedTransaction> categorizedTransactions = categorizeTransactions(ofxTransactions);
-        cli.println(String.format("Successfully imported %d transactions", categorizedTransactions.size()));
+        final ImportResult result = categorizeTransactions(ofxTransactions);
+        final String importMessage = result.duplicateCount() > 0
+                ? String.format(
+                        "Successfully imported %d transactions (%d duplicates skipped)",
+                        result.transactions().size(), result.duplicateCount())
+                : String.format(
+                        "Successfully imported %d transactions",
+                        result.transactions().size());
+        cli.println(importMessage);
     }
 
-    // TODO: return number of ignored duplicate transactions so that this info can be displayed in UI
-    public List<CategorizedTransaction> categorizeTransactions(final List<OfxExport> ofxExports) {
+    public ImportResult categorizeTransactions(final List<OfxExport> ofxExports) {
         final Map<Account, List<Transaction>> accountTransactions = new HashMap<>();
         for (OfxExport ofxExport : ofxExports) {
             // figure out which account these transactions belong to
@@ -171,6 +178,7 @@ public class TransactionImportService {
         // at this point, we can attempt to identify inter-account transfers
         final List<CategorizedTransaction> categorizedTransactions =
                 new ArrayList<>(identifyTransfers(accountTransactions));
+        final AtomicInteger duplicateCount = new AtomicInteger(0);
 
         for (Map.Entry<Account, List<Transaction>> entry : accountTransactions.entrySet()) {
             // TODO: this can probably be cleaned up too
@@ -179,6 +187,7 @@ public class TransactionImportService {
                 try (DatabaseTransaction t = new DatabaseTransaction(connection)) {
                     if (categorizedTransactionDao.isDuplicate(t, transaction)) {
                         logger.info("Ignored duplicate Transaction {}", transaction);
+                        duplicateCount.incrementAndGet();
                         return;
                     }
 
@@ -216,7 +225,7 @@ public class TransactionImportService {
         // days to clear
         identifyTransfers(categorizedTransactionDao.findUnlinkedTransfers());
 
-        return categorizedTransactions;
+        return new ImportResult(categorizedTransactions, duplicateCount.get());
     }
 
     private List<CategorizedTransaction> identifyTransfers(Map<Account, List<Transaction>> accountTransactions) {

--- a/src/test/java/ca/jonathanfritz/ofxcat/integration/ImportFlowIntegrationTest.java
+++ b/src/test/java/ca/jonathanfritz/ofxcat/integration/ImportFlowIntegrationTest.java
@@ -128,7 +128,8 @@ class ImportFlowIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = transactionImportService.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: All 10 transactions were imported
         assertEquals(10, imported.size(), "All 10 transactions should be imported");
@@ -185,7 +186,8 @@ class ImportFlowIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> firstImport = tis1.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> firstImport =
+                tis1.categorizeTransactions(ofxExports).transactions();
         assertEquals(2, firstImport.size(), "First import should have 2 transactions");
 
         // Second import of same file
@@ -206,7 +208,8 @@ class ImportFlowIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> secondImport = tis2.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> secondImport =
+                tis2.categorizeTransactions(ofxExports).transactions();
         assertEquals(0, secondImport.size(), "Second import should have 0 new transactions (duplicates ignored)");
 
         // Verify database still has only 2 transactions (by checking fitIds from first import)
@@ -258,7 +261,8 @@ class ImportFlowIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = tis.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                tis.categorizeTransactions(ofxExports).transactions();
 
         // Verify
         assertEquals(3, imported.size());
@@ -311,7 +315,8 @@ class ImportFlowIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = tis.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                tis.categorizeTransactions(ofxExports).transactions();
 
         // Verify
         assertEquals(4, imported.size());

--- a/src/test/java/ca/jonathanfritz/ofxcat/integration/MultiAccountIntegrationTest.java
+++ b/src/test/java/ca/jonathanfritz/ofxcat/integration/MultiAccountIntegrationTest.java
@@ -113,7 +113,8 @@ class MultiAccountIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = tis.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                tis.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Both transactions imported
         assertEquals(2, imported.size(), "Both transfer transactions should be imported");
@@ -199,7 +200,8 @@ class MultiAccountIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = tis.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                tis.categorizeTransactions(ofxExports).transactions();
 
         // Verify: All 6 transactions imported
         assertEquals(6, imported.size(), "All 6 transactions should be imported");
@@ -263,7 +265,8 @@ class MultiAccountIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> firstImport = tis1.categorizeTransactions(checkingExport);
+        List<CategorizedTransaction> firstImport =
+                tis1.categorizeTransactions(checkingExport).transactions();
 
         // Verify first import: Transaction imported, no transfer yet
         assertEquals(1, firstImport.size());
@@ -300,7 +303,8 @@ class MultiAccountIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> secondImport = tis2.categorizeTransactions(savingsExport);
+        List<CategorizedTransaction> secondImport =
+                tis2.categorizeTransactions(savingsExport).transactions();
 
         // Verify second import: Transaction imported, transfer now matched
         assertEquals(1, secondImport.size());
@@ -353,7 +357,8 @@ class MultiAccountIntegrationTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> imported = tis.categorizeTransactions(ofxExports);
+        List<CategorizedTransaction> imported =
+                tis.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Transaction imported
         assertEquals(1, imported.size());

--- a/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportServiceBalanceTest.java
+++ b/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportServiceBalanceTest.java
@@ -80,7 +80,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: No transactions imported, no errors
         Assertions.assertEquals(0, result.size());
@@ -125,7 +126,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Transaction balance equals final balance (the balance AFTER the transaction)
         Assertions.assertEquals(1, result.size());
@@ -187,7 +189,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Transaction balance equals final balance (the balance AFTER the transaction)
         Assertions.assertEquals(1, result.size());
@@ -248,7 +251,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Three transactions with correct running balances
         Assertions.assertEquals(3, result.size());
@@ -308,7 +312,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Balances calculated in chronological order despite OFX file order
         Assertions.assertEquals(3, result.size());
@@ -372,7 +377,8 @@ class TransactionImportServiceBalanceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Verify: Transactions processed in correct chronological order
         Assertions.assertEquals(2, result.size());

--- a/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportServiceTest.java
+++ b/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportServiceTest.java
@@ -84,7 +84,7 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
         final List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(ofxExports);
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
         Assertions.assertEquals(1, categorizedTransactions.size());
         Assertions.assertEquals(
                 fitId, categorizedTransactions.get(0).getTransaction().getFitId());
@@ -137,9 +137,9 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transferDao,
                 transactionTokenDao,
                 tokenNormalizer);
-        final List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(ofxExports);
-        Assertions.assertTrue(categorizedTransactions.isEmpty());
+        final ImportResult result = transactionImportService.categorizeTransactions(ofxExports);
+        Assertions.assertTrue(result.transactions().isEmpty());
+        Assertions.assertEquals(1, result.duplicateCount());
 
         // make sure that the original transaction still exists
         // this will throw an SQLException if there are two transactions with the same FitID
@@ -197,7 +197,7 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
         final List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(ofxExports);
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         Assertions.assertEquals(2, categorizedTransactions.size());
         Assertions.assertTrue(
@@ -279,7 +279,7 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
         List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(sourceOfxFile);
+                transactionImportService.categorizeTransactions(sourceOfxFile).transactions();
 
         // the source transaction was categorized, printed to the CLI, and inserted into the database; a transfer was
         // not created
@@ -313,7 +313,8 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transferDao,
                 transactionTokenDao,
                 tokenNormalizer);
-        categorizedTransactions = transactionImportService.categorizeTransactions(sinkOfxFile);
+        categorizedTransactions =
+                transactionImportService.categorizeTransactions(sinkOfxFile).transactions();
 
         // the sink transaction was categorized, printed to the CLI, and inserted into the database
         Assertions.assertEquals(1, categorizedTransactions.size());
@@ -440,7 +441,7 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
         final List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(ofxExports);
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // the transaction was categorized with the brand new category
         Assertions.assertEquals(1, categorizedTransactions.size());
@@ -510,7 +511,8 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = tis.categorizeTransactions(List.of(ofxExport));
+        final List<CategorizedTransaction> result =
+                tis.categorizeTransactions(List.of(ofxExport)).transactions();
 
         // With AVAILBAL anchor: initialBalance = 1000.00 - (-100.00) = 1100.00; balance = 1000.00
         // With LEDGERBAL anchor: balance would be 750.00
@@ -565,7 +567,8 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = tis.categorizeTransactions(List.of(ofxExport));
+        final List<CategorizedTransaction> result =
+                tis.categorizeTransactions(List.of(ofxExport)).transactions();
 
         // With LEDGERBAL anchor: initialBalance = 900.00 - (-100.00) = 1000.00; balance = 900.00
         Assertions.assertEquals(1, result.size());
@@ -625,7 +628,8 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = tis.categorizeTransactions(List.of(ofxExport));
+        final List<CategorizedTransaction> result =
+                tis.categorizeTransactions(List.of(ofxExport)).transactions();
 
         // With LEDGERBAL anchor: initialBalance = -622.69 - (-100.00) = -522.69; balance = -622.69
         // With AVAILBAL anchor: balance would be 9377.31 (wrong)
@@ -664,7 +668,7 @@ class TransactionImportServiceTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
         final List<CategorizedTransaction> categorizedTransactions =
-                transactionImportService.categorizeTransactions(ofxExports);
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // the transaction was categorized as UNKNOWN
         Assertions.assertEquals(1, categorizedTransactions.size());

--- a/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportTokenStorageTest.java
+++ b/src/test/java/ca/jonathanfritz/ofxcat/service/TransactionImportTokenStorageTest.java
@@ -83,7 +83,8 @@ class TransactionImportTokenStorageTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Then: The transaction was imported
         assertEquals(1, result.size());
@@ -136,7 +137,8 @@ class TransactionImportTokenStorageTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Then: The transaction was imported with UNKNOWN category
         assertEquals(1, result.size());
@@ -184,7 +186,8 @@ class TransactionImportTokenStorageTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        final List<CategorizedTransaction> result = transactionImportService.categorizeTransactions(ofxExports);
+        final List<CategorizedTransaction> result =
+                transactionImportService.categorizeTransactions(ofxExports).transactions();
 
         // Then: Both transactions were imported
         assertEquals(2, result.size());
@@ -230,7 +233,8 @@ class TransactionImportTokenStorageTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> firstResult = firstImportService.categorizeTransactions(firstExport);
+        List<CategorizedTransaction> firstResult =
+                firstImportService.categorizeTransactions(firstExport).transactions();
         assertEquals(1, firstResult.size());
         assertEquals(groceryCategory, firstResult.getFirst().getCategory());
 
@@ -259,7 +263,8 @@ class TransactionImportTokenStorageTest extends AbstractDatabaseTest {
                 transactionTokenDao,
                 tokenNormalizer);
 
-        List<CategorizedTransaction> secondResult = secondImportService.categorizeTransactions(secondExport);
+        List<CategorizedTransaction> secondResult =
+                secondImportService.categorizeTransactions(secondExport).transactions();
 
         // Then: The second transaction was auto-categorized using token matching
         assertEquals(1, secondResult.size());


### PR DESCRIPTION
categorizeTransactions() now returns ImportResult, which bundles the
imported transactions list alongside a count of duplicates that were
silently skipped. importTransactions() displays the count in the
success message when at least one duplicate was detected.

https://claude.ai/code/session_011kaF1TN5CGDZTAXh7ttoma